### PR TITLE
Allow to sendDataList after each Identify call

### DIFF
--- a/src/main/java/com/fr3ts0n/androbd/plugin/Plugin.java
+++ b/src/main/java/com/fr3ts0n/androbd/plugin/Plugin.java
@@ -236,6 +236,9 @@ public abstract class Plugin
      */
     protected void handleIdentify(Context context, Intent intent)
     {
+        // the host application may have restarted since we last sent data headers
+        headerSent = false;
+
         // remember broadcasting host application
         hostInfo = new PluginInfo(intent.getExtras());
 


### PR DESCRIPTION
The host application sends an Identify request each time it starts up, in which case it won't remember the previous data headers we've sent.
This change will allow data headers to be sent again after receiving an Identify request.