### PR TITLE
Add support for binding Plugin services directly

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -16,4 +16,10 @@
 
     </application>
 
+    <queries>
+        <!-- Search for plugins -->
+        <intent>
+            <action android:name="com.fr3ts0n.androbd.plugin.IDENTIFY" />
+        </intent>
+    </queries>
 </manifest>

--- a/src/main/java/com/fr3ts0n/androbd/plugin/PluginInfo.java
+++ b/src/main/java/com/fr3ts0n/androbd/plugin/PluginInfo.java
@@ -124,4 +124,27 @@ public class PluginInfo
     {
         return className;
     }
+
+    @Override
+    public boolean equals(Object o)
+    {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        PluginInfo that = (PluginInfo) o;
+
+        if (name != null ? !name.equals(that.name) : that.name != null) return false;
+        if (packageName != null ? !packageName.equals(that.packageName) : that.packageName != null)
+            return false;
+        return className != null ? className.equals(that.className) : that.className == null;
+    }
+
+    @Override
+    public int hashCode()
+    {
+        int result = name != null ? name.hashCode() : 0;
+        result = 31 * result + (packageName != null ? packageName.hashCode() : 0);
+        result = 31 * result + (className != null ? className.hashCode() : 0);
+        return result;
+    }
 }

--- a/src/main/java/com/fr3ts0n/androbd/plugin/mgr/PluginHandler.java
+++ b/src/main/java/com/fr3ts0n/androbd/plugin/mgr/PluginHandler.java
@@ -1,10 +1,12 @@
 package com.fr3ts0n.androbd.plugin.mgr;
 
 import android.content.BroadcastReceiver;
+import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.SharedPreferences;
+import android.content.pm.ResolveInfo;
 import android.preference.PreferenceManager;
 import android.util.Log;
 import android.view.LayoutInflater;
@@ -19,6 +21,8 @@ import android.widget.TextView;
 import com.fr3ts0n.androbd.plugin.Plugin;
 import com.fr3ts0n.androbd.plugin.PluginInfo;
 import com.fr3ts0n.androbd.plugin.R;
+
+import java.util.List;
 
 /**
  * Plugin handler
@@ -274,8 +278,18 @@ public class PluginHandler
         Intent intent = new Intent(Plugin.IDENTIFY);
         intent.addCategory(Plugin.REQUEST);
         intent.putExtras(svc.getPluginInfo().toBundle());
-        Log.i(toString(), ">IDENTIFY: " + intent);
-        getContext().sendBroadcast(intent);
+
+        List<ResolveInfo> receiverPlugins = getContext().getPackageManager().queryBroadcastReceivers(intent, 0);
+        for (ResolveInfo plugin: receiverPlugins)
+        {
+            if (plugin.activityInfo != null)
+            {
+                ComponentName component = new ComponentName(plugin.activityInfo.packageName, plugin.activityInfo.name);
+                Intent explicitIntent = intent.setComponent(component);
+                Log.i(toString(), ">IDENTIFY: " + intent);
+                getContext().sendBroadcast(explicitIntent);
+            }
+        }
     }
 
     /**

--- a/src/main/java/com/fr3ts0n/androbd/plugin/mgr/PluginHandler.java
+++ b/src/main/java/com/fr3ts0n/androbd/plugin/mgr/PluginHandler.java
@@ -5,8 +5,10 @@ import android.content.ComponentName;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
+import android.content.ServiceConnection;
 import android.content.SharedPreferences;
 import android.content.pm.ResolveInfo;
+import android.os.IBinder;
 import android.preference.PreferenceManager;
 import android.util.Log;
 import android.view.LayoutInflater;
@@ -22,7 +24,11 @@ import com.fr3ts0n.androbd.plugin.Plugin;
 import com.fr3ts0n.androbd.plugin.PluginInfo;
 import com.fr3ts0n.androbd.plugin.R;
 
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * Plugin handler
@@ -69,8 +75,8 @@ public class PluginHandler
                 Log.i(toString(), "Plugin identified: " + plugin.toString());
                 // get preferred enable/disable state from settings
                 plugin.enabled = mPrefs.getBoolean(plugin.className, true);
-                // add plugin to list
-                add(plugin);
+                // add (or replace) plugin in the list
+                upsert(plugin);
                 // set current enabled/disabled state (to stop disabled services)
                 setPluginEnabled(getPosition(plugin), plugin.enabled);
             }
@@ -79,6 +85,47 @@ public class PluginHandler
             context.startService(intent);
         }
     };
+
+    /**
+     * the listener to receive bindService callbacks
+     */
+    private class BoundServiceConnection implements ServiceConnection
+    {
+        private final String name;
+        public BoundServiceConnection(String name)
+        {
+            this.name = name;
+        }
+
+        @Override
+        public void onServiceConnected(ComponentName name, IBinder service)
+        {
+            Log.i(toString(), "Successful binding to " + this.name);
+        }
+
+        @Override
+        public void onNullBinding(ComponentName name)
+        {
+            Log.i(toString(), "Successful null binding to " + this.name);
+        }
+
+        @Override
+        public void onBindingDied(ComponentName name)
+        {
+            Log.i(toString(), "Binding died to " + this.name);
+        }
+
+        @Override
+        public void onServiceDisconnected(ComponentName name)
+        {
+            Log.i(toString(), "Successful unbinding to " + this.name);
+        }
+    }
+
+    /**
+     * The collection of currently-bound plugin services
+     */
+    private Map<String, ServiceConnection> mBoundServices;
 
     /**
      * Constructor
@@ -103,7 +150,27 @@ public class PluginHandler
 
         mPrefs = PreferenceManager.getDefaultSharedPreferences(context);
 
-        setup();
+        mBoundServices = new HashMap<>();
+    }
+
+    /**
+     * Adds or replaces a single item in this ArrayAdapter
+     * @param item
+     */
+    public void upsert(PluginInfo item)
+    {
+        int index = getPosition(item);
+        if (index < 0)
+        {
+            add(item);
+        }
+        else
+        {
+            setNotifyOnChange(false);
+            remove(item);
+            setNotifyOnChange(true);
+            insert(item, index);
+        }
     }
 
     @Override
@@ -259,12 +326,15 @@ public class PluginHandler
 
         if (enable)
         {
+            // make sure plugin is running
+            bindPlugin(plugin.packageName, plugin.className);
             // initiate plugin action
             triggerAction(position);
         }
         else
         {
             // actively stop plugin service if switched off
+            unbindPlugin(plugin.packageName);
             stopPlugin(position);
         }
     }
@@ -280,15 +350,78 @@ public class PluginHandler
         intent.putExtras(svc.getPluginInfo().toBundle());
 
         List<ResolveInfo> receiverPlugins = getContext().getPackageManager().queryBroadcastReceivers(intent, 0);
+        List<ResolveInfo> servicePlugins = getContext().getPackageManager().queryIntentServices(intent, 0);
+        Set<String> discoveredPlugins = new HashSet<>();
+
+        // Binds the Plugin service into memory
+        for (ResolveInfo plugin: servicePlugins)
+        {
+            if (plugin.serviceInfo != null && !discoveredPlugins.contains(plugin.serviceInfo.packageName))
+            {
+                discoveredPlugins.add(plugin.serviceInfo.packageName);
+
+                ComponentName component = new ComponentName(plugin.serviceInfo.packageName, plugin.serviceInfo.name);
+                Intent explicitIntent = intent.setComponent(component);
+                Log.i(toString(), ">IDENTIFY: " + intent);
+
+                // bind the service to make sure it stays in memory
+                bindPlugin(plugin.serviceInfo.packageName, plugin.serviceInfo.name);
+
+                // send the actual command
+                getContext().startService(explicitIntent);
+            }
+        }
+
         for (ResolveInfo plugin: receiverPlugins)
         {
-            if (plugin.activityInfo != null)
+            if (plugin.activityInfo != null && !discoveredPlugins.contains(plugin.activityInfo.packageName))
             {
+                discoveredPlugins.add(plugin.serviceInfo.packageName);
                 ComponentName component = new ComponentName(plugin.activityInfo.packageName, plugin.activityInfo.name);
                 Intent explicitIntent = intent.setComponent(component);
                 Log.i(toString(), ">IDENTIFY: " + intent);
                 getContext().sendBroadcast(explicitIntent);
             }
+        }
+    }
+
+    /**
+     * Binds the given plugin service into memory
+     *
+     * @param packageName The package name for the plugin
+     * @param className The class name for the Plugin service in that package
+     */
+    private void bindPlugin(String packageName, String className)
+    {
+        if (!mBoundServices.containsKey(packageName))
+        {
+            Intent intent = new Intent(Plugin.IDENTIFY);
+            intent.addCategory(Plugin.REQUEST);
+            ComponentName component = new ComponentName(packageName, className);
+            intent.setComponent(component);
+
+            ServiceConnection serviceConnection = new BoundServiceConnection(packageName);
+            getContext().bindService(intent, serviceConnection, Context.BIND_AUTO_CREATE);
+            mBoundServices.put(packageName, serviceConnection);
+        }
+    }
+
+    /**
+     * Disconnects the service binding to this plugin
+     *
+     * @param packageName The package name for the plugin
+     */
+    private void unbindPlugin(String packageName) {
+        if (mBoundServices.containsKey(packageName))
+        {
+            try
+            {
+                getContext().unbindService(mBoundServices.get(packageName));
+            } catch (Exception e)
+            {
+                // error while disconnecting
+            }
+            mBoundServices.remove(packageName);
         }
     }
 
@@ -303,6 +436,7 @@ public class PluginHandler
         PluginInfo plugin = getItem(position);
         intent.setClassName(plugin.packageName, plugin.className);
         Log.i(toString(), "Stop service: " + intent);
+        unbindPlugin(plugin.packageName);
         getContext().stopService(intent);
     }
 

--- a/src/main/java/com/fr3ts0n/androbd/plugin/mgr/PluginManager.java
+++ b/src/main/java/com/fr3ts0n/androbd/plugin/mgr/PluginManager.java
@@ -2,6 +2,7 @@ package com.fr3ts0n.androbd.plugin.mgr;
 
 import android.app.ListActivity;
 import android.os.Bundle;
+import android.os.Handler;
 import android.view.View;
 import android.widget.Switch;
 
@@ -34,6 +35,23 @@ public class PluginManager
             pluginHandler = new PluginHandler(this);
             pluginHandler.setDataReceiver(this);
         }
+    }
+
+    @Override
+    protected void onResume()
+    {
+        super.onResume();
+
+        // discover plugins after showing the activity
+        // before onResume completes, the app is still in the background and can't start services
+        new Handler().post(new Runnable()
+        {
+            @Override
+            public void run()
+            {
+                pluginHandler.setup();
+            }
+        });
     }
 
     @Override


### PR DESCRIPTION
This improves discovering and starting Plugins in newer Android versions.
It also changes to using an explicit intent for the existing BroadcastReceiver plugins.