### PR TITLE
Allow plugins to bind AndrOBD into memory

### DIFF
--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -12,6 +12,11 @@
         <service
             android:name="com.fr3ts0n.androbd.plugin.mgr.PluginDataService"
             android:exported="true">
+            <!-- Allow other plugins to bind the main plugin service to keep it alive -->
+            <intent-filter>
+                <action android:name="com.fr3ts0n.androbd.plugin.IDENTIFY" />
+                <category android:name="com.fr3ts0n.androbd.plugin.REQUEST" />
+            </intent-filter>
         </service>
 
     </application>

--- a/src/main/java/com/fr3ts0n/androbd/plugin/mgr/PluginHandler.java
+++ b/src/main/java/com/fr3ts0n/androbd/plugin/mgr/PluginHandler.java
@@ -356,6 +356,7 @@ public class PluginHandler
         List<ResolveInfo> receiverPlugins = getContext().getPackageManager().queryBroadcastReceivers(intent, 0);
         List<ResolveInfo> servicePlugins = getContext().getPackageManager().queryIntentServices(intent, 0);
         Set<String> discoveredPlugins = new HashSet<>();
+        discoveredPlugins.add(getContext().getPackageName());       // don't try to discover the host application
 
         // Binds the Plugin service into memory
         for (ResolveInfo plugin: servicePlugins)


### PR DESCRIPTION
The CSV Logger plugin would like to keep AndrOBD active and forwarding data, even if the user has switched away to a different app, and this service intent-filter enables this.

This goes along with [this functionality](https://github.com/hufman/AndrOBD-Plugin/commit/2bcce7c978c1f4d304e06382c61d83e98cacd9be#diff-ad1ba9f5eb867c215268fba45d66a88235574cd6e527645f3ce633f92f6fa830R75) of the CSV Logger. The CSV Logger starts up a Foreground Service Notification to keep the CSV Logger in memory and available for quick access to AndrOBD and to Stop Recording, and it uses this service binding to keep the main AndrOBD active via the Foreground Notification.